### PR TITLE
fix repo-name for layman

### DIFF
--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,1 +1,1 @@
-ejabberd-overlay
+ejabberd


### PR DESCRIPTION
repo-name in repo_name and layman must be the same